### PR TITLE
fix action name on README.md [sc-71142]

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Whenever you change your model files, the Impact Report by Select Star will crea
             pull-requests: write 
           steps:
             - name: Run Action
-              uses: selectstar/dbt-impact-report@v1
+              uses: selectstar/dbt-impact-report-action@v1
               with:
                 GIT_REPOSITORY_TOKEN: ${{secrets.GITHUB_TOKEN}}   # no need to change, GitHub will handle it as it is
                 SELECTSTAR_API_TOKEN: ${{secrets.SELECTSTAR_API_TOKEN}}


### PR DESCRIPTION
## Description

Use the public action name on code example instead of the repository name

## How to reproduce/test?

Our dbt-selectstar is already using the correct reference, we are just missing it in the readme file.
https://github.com/selectstar/dbt-selectstar/blob/main/.github/workflows/select-star-impact-report.yml

## Type of change

-   [ ] Refactor (non-breaking change that improves codebase).
-   [X] Bug fix (non-breaking change that fixes an issue).
-   [ ] New feature (non-breaking change that adds functionality).
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
-   [ ] Chore (none of the above, but still important)

## Checklists

-   [ ] No backend changes needed.
-   [ ] All related backend changes are ready.
    -   [links to related PRs]
