### PR TITLE
Use the new data structure of the warehouse link API [sc-75355]

### DIFF
--- a/src/dataobjects.py
+++ b/src/dataobjects.py
@@ -78,7 +78,7 @@ class WarehouseLink(ReportObject):
         self.table = None
 
     def _extract_attributes(self, data: dict):
-        self.guid = data.get("warehouse_table").get("guid")
+        self.guid = data["warehouse_table"]["guid"]
 
     def set_table(self, data: dict):
         self.table = TableLinked(data=data)

--- a/src/dataobjects.py
+++ b/src/dataobjects.py
@@ -78,7 +78,7 @@ class WarehouseLink(ReportObject):
         self.table = None
 
     def _extract_attributes(self, data: dict):
-        self.guid = data.get("warehouse_table")
+        self.guid = data.get("warehouse_table").get("guid")
 
     def set_table(self, data: dict):
         self.table = TableLinked(data=data)

--- a/src/selectstar.py
+++ b/src/selectstar.py
@@ -96,7 +96,7 @@ class SelectStar:
 
             found_links = response.json()
 
-            for link in found_links:
+            for link in found_links.get("results"):
                 warehouse_link = WarehouseLink(link)
                 warehouse_link.set_table(self.__get_table(warehouse_link.guid))
                 model.warehouse_links.append(warehouse_link)

--- a/src/selectstar.py
+++ b/src/selectstar.py
@@ -96,7 +96,7 @@ class SelectStar:
 
             found_links = response.json()
 
-            for link in found_links.get("results"):
+            for link in found_links["results"]:
                 warehouse_link = WarehouseLink(link)
                 warehouse_link.set_table(self.__get_table(warehouse_link.guid))
                 model.warehouse_links.append(warehouse_link)


### PR DESCRIPTION
## Description

The response structure changed and is breaking the impact report

sc-75355

## How to reproduce/test?

Can be seen on this PR https://github.com/selectstar/dbt-selectstar/pull/339, its using this branch to create the report (https://github.com/selectstar/dbt-selectstar/pull/339/files). Just re-rerun the action.

## Type of change

-   [ ] Refactor (non-breaking change that improves codebase).
-   [X] Bug fix (non-breaking change that fixes an issue).
-   [ ] New feature (non-breaking change that adds functionality).
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
-   [ ] Chore (none of the above, but still important)

## Checklists

-   [X] No backend changes needed.
-   [ ] All related backend changes are ready.
    -   [links to related PRs]
