### PR TITLE
Enforce model name uniqueness [sc-87876]

### DIFF
--- a/src/git.py
+++ b/src/git.py
@@ -67,13 +67,11 @@ class Git:
                 else:
                     found_models[project_relative_filepath] = DbtModel(data=file, project_relative_filepath=result.group(0))
 
-        unique_found_models: list[DbtModel] = list(found_models.values())
-
         log.info(
-            f"Found models: {[(f.project_relative_filepath, f.status) for f in unique_found_models]}"
+            f"Found models: {[(f.project_relative_filepath, f.status) for f in list(found_models.values())]}"
         )
 
-        return unique_found_models
+        return list(found_models.values())
 
     def __get_impact_report_comment_id(self) -> dict | None:
         url = self._get_list_comments_url()

--- a/src/git.py
+++ b/src/git.py
@@ -65,7 +65,9 @@ class Git:
                         f"Model {project_relative_filepath} already found. Skipping."
                     )
                 else:
-                    found_models[project_relative_filepath] = DbtModel(data=file, project_relative_filepath=result.group(0))
+                    found_models[project_relative_filepath] = DbtModel(
+                        data=file, project_relative_filepath=result.group(0)
+                    )
 
         log.info(
             f"Found models: {[(f.project_relative_filepath, f.status) for f in list(found_models.values())]}"


### PR DESCRIPTION
## Description

More logs and enforce that the file being processed is unique.

There are cases where GitHub will report the "same" file in a single PR (cases found in the internet speak about it being the result of branches with code conflict or when the dev machine OS is case sensitive, so GH will show both as lower case).
Works as usual, but I could not reproduce the file duplication on our instance project.

## How to reproduce/test?

Go to https://github.com/selectstar/dbt-selectstar
Create a new branch from master
Alter the .github/workflows/select-star-impact-report.yml to use this branch as tag
Alter one or more .sql files under models folder, commit, push
Open a PR between this new branch and master
The action will run and a report should be created

## Type of change

-   [X] Refactor (non-breaking change that improves codebase).
-   [X] Bug fix (non-breaking change that fixes an issue).
-   [ ] New feature (non-breaking change that adds functionality).
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
-   [ ] Chore (none of the above, but still important)

## Checklists

-   [X] No backend changes needed.
-   [X] All related backend changes are ready.
    -   [links to related PRs]
