### PR TITLE
Regex fix [sc-87876]

### DIFF
--- a/src/git.py
+++ b/src/git.py
@@ -56,7 +56,7 @@ class Git:
 
         for file in files:
             result = re.search(
-                r"models/(.+/)?\w+.sql", file.get("filename"), flags=re.IGNORECASE
+                r"models/(.+/)?\w+\.sql$", file.get("filename"), flags=re.IGNORECASE
             )
             if result:
                 project_relative_filepath = result.group(0)


### PR DESCRIPTION
## Description

Regex mismatch was accepting filenames where "sql" was part of the name, not the extension. E.g: models/thrive_tpg_mysql_rds/email_connector_db/email_attachment.yml was an incorrect match.

## How to reproduce/test?

Here is a test case:

Incorrect (current v1 version): https://github.com/selectstar/dbt-selectstar/pull/543#issuecomment-2148049859
"models/thrive_tpg_mysql_rds/some_model" should not be listed, as it has .yml extension (matched due to the SQL string in the subfolder name 'thrive_tpg_mysql_rds')

Correct (local execution with new regex): https://github.com/selectstar/dbt-selectstar/pull/543#issuecomment-2150417941



## Type of change

-   [ ] Refactor (non-breaking change that improves codebase).
-   [X] Bug fix (non-breaking change that fixes an issue).
-   [ ] New feature (non-breaking change that adds functionality).
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
-   [ ] Chore (none of the above, but still important)

## Checklists

-   [X] No backend changes needed.
-   [X] All related backend changes are ready.
    -   [links to related PRs]
