### PR TITLE
Deduplicate downstream objects (model X dwh link) [sc-85895]

### DIFF
--- a/src/dataobjects.py
+++ b/src/dataobjects.py
@@ -34,6 +34,8 @@ class DownstreamElement(ReportObject):
         self.type = data.get("data_type") or "-"
         self.full_name = data.get("full_name")
         self.data_source_type = data.get("data_source_type")
+        self.linked_objects = data.get("linked_objs") or []
+        self.linked_object_data_source_type = None
         if data.get("popularity"):
             self.popularity = Popularity(data.get("popularity"))
         else:
@@ -96,3 +98,5 @@ class DbtModel(ReportObject):
         self.guid = None
         self.warehouse_links = []
         self.downstream_elements = []
+        # my downstream elements + warehouse linked table downstream elements
+        self.all_unique_downstream_elements = []

--- a/src/report_printer.py
+++ b/src/report_printer.py
@@ -118,8 +118,10 @@ class ReportPrinter:
                     f"{self.select_star_web_url}/tables/{model_element.guid}/overview"
                 )
                 if model_element.linked_object_data_source_type:
-                    source_types = (f"{self._build_datasource_img_tag(model_element.data_source_type)} {model_element.data_source_type}<br/>"
-                                   f"{self._build_datasource_img_tag(model_element.linked_object_data_source_type)} {model_element.linked_object_data_source_type}")
+                    source_types = (
+                        f"{self._build_datasource_img_tag(model_element.data_source_type)} {model_element.data_source_type}<br/>"
+                        f"{self._build_datasource_img_tag(model_element.linked_object_data_source_type)} {model_element.linked_object_data_source_type}"
+                    )
                 else:
                     source_types = f"{self._build_datasource_img_tag(model_element.data_source_type)} {model_element.data_source_type}"
 

--- a/src/report_printer.py
+++ b/src/report_printer.py
@@ -119,7 +119,7 @@ class ReportPrinter:
                 )
                 if model_element.linked_object_data_source_type:
                     source_types = (
-                        f"{self._build_datasource_img_tag(model_element.data_source_type)} {model_element.data_source_type}<br/>"
+                        f"{self._build_datasource_img_tag(model_element.data_source_type)} {model_element.data_source_type} / "
                         f"{self._build_datasource_img_tag(model_element.linked_object_data_source_type)} {model_element.linked_object_data_source_type}"
                     )
                 else:

--- a/src/report_printer.py
+++ b/src/report_printer.py
@@ -119,7 +119,7 @@ class ReportPrinter:
                 )
                 if model_element.linked_object_data_source_type:
                     source_types = (f"{self._build_datasource_img_tag(model_element.data_source_type)} {model_element.data_source_type}<br/>"
-                                   f"{self._build_datasource_img_tag(model_element.linked_object_data_source_type)} {model_element.linked_object_data_source_type}<br/>")
+                                   f"{self._build_datasource_img_tag(model_element.linked_object_data_source_type)} {model_element.linked_object_data_source_type}")
                 else:
                     source_types = f"{self._build_datasource_img_tag(model_element.data_source_type)} {model_element.data_source_type}"
 

--- a/src/report_printer.py
+++ b/src/report_printer.py
@@ -58,7 +58,7 @@ class ReportPrinter:
         lines = [
             f"<img src='{self.select_star_web_url}/icons/dbt.svg' width='15' height='15' align='center'> "
             f"{model.filepath.split('.')[0]}\n",
-            f"Model not found in Select Star database. This model may be hidden or not ingested.",
+            "Model not found in Select Star database. This model may be hidden or not ingested.",
         ]
 
         return "".join(lines)
@@ -84,18 +84,14 @@ class ReportPrinter:
                 f"{linked_table.schema.name}/{linked_table.name}]({linked_table_link})"
             )
         else:
-            maps_to = f" has no linked warehouse table"
+            maps_to = " has no linked warehouse table"
 
         lines.append(
             f"<img src='{self.select_star_web_url}/icons/dbt.svg' width='15' height='15' align='center'> "
             f"[{model.filepath.split('.')[0]}]({model_url}){maps_to}\n"
         )
 
-        total_impact_number = len(model.downstream_elements)
-        if model.warehouse_links:
-            total_impact_number = total_impact_number + len(
-                model.warehouse_links[0].table.downstream_elements
-            )
+        total_impact_number = len(model.all_unique_downstream_elements)
 
         if total_impact_number > 0:
             lines.append(
@@ -111,12 +107,7 @@ class ReportPrinter:
                 "| # | Data Source Type | Object Type | Name |\n|--------|--------|--------|--------|\n"
             )
 
-            all_downstream_elements = model.downstream_elements
-            if model.warehouse_links:
-                all_downstream_elements = (
-                    all_downstream_elements
-                    + model.warehouse_links[0].table.downstream_elements
-                )
+            all_downstream_elements = model.all_unique_downstream_elements
 
             all_downstream_elements.sort(
                 key=attrgetter("data_source_type", "type", "name")
@@ -126,10 +117,15 @@ class ReportPrinter:
                 obj_url = (
                     f"{self.select_star_web_url}/tables/{model_element.guid}/overview"
                 )
+                if model_element.linked_object_data_source_type:
+                    source_types = (f"{self._build_datasource_img_tag(model_element.data_source_type)} {model_element.data_source_type}<br/>"
+                                   f"{self._build_datasource_img_tag(model_element.linked_object_data_source_type)} {model_element.linked_object_data_source_type}<br/>")
+                else:
+                    source_types = f"{self._build_datasource_img_tag(model_element.data_source_type)} {model_element.data_source_type}"
+
                 lines.append(
                     f"|{idx}"
-                    f"|{self._build_datasource_img_tag(model_element.data_source_type)}"
-                    f" {model_element.data_source_type}"
+                    f"|{source_types}"
                     f"|{model_element.type}"
                     f"|[{model_element.name}]({obj_url})|\n"
                 )

--- a/src/selectstar.py
+++ b/src/selectstar.py
@@ -206,6 +206,6 @@ class SelectStar:
         self.__get_warehouse_links(dbt_models=dbt_models)
         log.info(" Fetching the dbt models full lineage")
         self.__get_full_lineage(dbt_models=dbt_models)
-        log.info(" Merge the linked objects")
+        log.info(" Deduplicate the downstream elements")
         self.__deduplicate_downstream(dbt_models=dbt_models)
         return dbt_models

--- a/src/selectstar.py
+++ b/src/selectstar.py
@@ -167,8 +167,8 @@ class SelectStar:
             all_downstream_elements = model.downstream_elements
             if model.warehouse_links:
                 all_downstream_elements = (
-                        all_downstream_elements
-                        + model.warehouse_links[0].table.downstream_elements
+                    all_downstream_elements
+                    + model.warehouse_links[0].table.downstream_elements
                 )
 
             # then we create a unique list of downstream elements
@@ -176,23 +176,39 @@ class SelectStar:
 
             # first we pick the dbt elements, they have priority over their links
             for downstream_element in all_downstream_elements:
-                if downstream_element.guid not in unique_downstream_elements and downstream_element.data_source_type == "dbt":
-                    unique_downstream_elements[downstream_element.guid] = downstream_element
+                if (
+                    downstream_element.guid not in unique_downstream_elements
+                    and downstream_element.data_source_type == "dbt"
+                ):
+                    unique_downstream_elements[
+                        downstream_element.guid
+                    ] = downstream_element
 
             # second we pick the other data source type elements and check if the linked object
             # is already in the list previously populated by dbt elements
             for downstream_element in all_downstream_elements:
-                if downstream_element.guid not in unique_downstream_elements and downstream_element.data_source_type != "dbt":
+                if (
+                    downstream_element.guid not in unique_downstream_elements
+                    and downstream_element.data_source_type != "dbt"
+                ):
                     is_unique = True
                     for linked_obj in downstream_element.linked_objects:
                         if linked_obj in unique_downstream_elements:
-                            unique_downstream_elements[linked_obj].linked_object_data_source_type = downstream_element.data_source_type
+                            unique_downstream_elements[
+                                linked_obj
+                            ].linked_object_data_source_type = (
+                                downstream_element.data_source_type
+                            )
                             is_unique = False
                             break
                     if is_unique:
-                        unique_downstream_elements[downstream_element.guid] = downstream_element
+                        unique_downstream_elements[
+                            downstream_element.guid
+                        ] = downstream_element
 
-            model.all_unique_downstream_elements = list(unique_downstream_elements.values())
+            model.all_unique_downstream_elements = list(
+                unique_downstream_elements.values()
+            )
 
     def get_lineage(self, dbt_models: list[DbtModel]):
         """


### PR DESCRIPTION
## Description

Hide (deduplicate) repeated downstream objects (dbt model and its dwh link are considered duplication).

## How to reproduce/test?

Use PR 670 of our dbt project (https://github.com/selectstar/dbt-selectstar/pull/670). The report posted by the github-actions bot is the current version, the report posted by me is the new version.

Differences:

- **table_model**: Removes the same table that comes with the dbt model AND the dwh linked table
- **incremental_model** and **ephemeral_model**: the snowflake linked table was removed and the snowflake icon added.

## Type of change

-   [ ] Refactor (non-breaking change that improves codebase).
-   [ ] Bug fix (non-breaking change that fixes an issue).
-   [X] New feature (non-breaking change that adds functionality).
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
-   [ ] Chore (none of the above, but still important)

## Checklists

-   [ ] No backend changes needed.
-   [ ] All related backend changes are ready.
    -   [links to related PRs]
