### PR TITLE
chore: ⬆️ Update GitHub Actions to use Ubuntu 24.04 [sc-108223]

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   pr-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change. -->

Ubuntu 20.04 runner image is deprecated ( https://github.com/actions/runner-images/issues/11101 ), so we should migrate all to Ubuntu 24.04 as the latest version available ( https://github.com/actions/runner-images/?tab=readme-ov-file#available-images ).

## How to reproduce/test?

<!-- Please please provide links or steps which help to check your submission. -->

## Type of change

-   [ ] Refactor (non-breaking change that improves codebase).
-   [ ] Bug fix (non-breaking change that fixes an issue).
-   [ ] New feature (non-breaking change that adds functionality).
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
-   [ ] Chore (none of the above, but still important)

## Checklists

-   [ ] No backend changes needed.
-   [ ] All related backend changes are ready.
    -   [links to related PRs]
